### PR TITLE
fixes to grammar

### DIFF
--- a/source/py_tutorials/py_imgproc/py_filtering/py_filtering.rst
+++ b/source/py_tutorials/py_imgproc/py_filtering/py_filtering.rst
@@ -7,21 +7,21 @@ Goals
 =======
 
 Learn to:
-    * Blur the images with various low pass filters
+    * Blur  imagess with various low pass filters
     * Apply custom-made filters to images (2D convolution)
     
 2D Convolution ( Image Filtering )
 ====================================
 
-As in one-dimensional signals, images also can be filtered with various low-pass filters(LPF), high-pass filters(HPF) etc. LPF helps in removing noises, blurring the images etc. HPF filters helps in finding edges in the images.
+As for one-dimensional signals, images also can be filtered with various low-pass filters (LPF), high-pass filters (HPF), etc. A LPF helps in removing noise, or blurring the image. A HPF filters helps in finding edges in an image.
 
-OpenCV provides a function **cv2.filter2D()** to convolve a kernel with an image. As an example, we will try an averaging filter on an image. A 5x5 averaging filter kernel will look like below:
+OpenCV provides a function, **cv2.filter2D()**, to convolve a kernel with an image. As an example, we will try an averaging filter on an image. A 5x5 averaging filter kernel can be defined as follows:
 
 .. math::
 
     K =  \frac{1}{25} \begin{bmatrix} 1 & 1 & 1 & 1 & 1  \\ 1 & 1 & 1 & 1 & 1 \\ 1 & 1 & 1 & 1 & 1 \\ 1 & 1 & 1 & 1 & 1 \\ 1 & 1 & 1 & 1 & 1 \end{bmatrix}
     
-Operation is like this: keep this kernel above a pixel, add all the 25 pixels below this kernel, take its average and replace the central pixel with the new average value. It continues this operation for all the pixels in the image. Try this code and check the result:
+Filtering with the above kernel results in the following being performed: for each pixel, a 5x5 window is centered on this pixel,  all pixels falling within this window are summed up, and the result is then divided by 25. This equates to computing the average of the pixel values inside that window. This operation is performed for all the pixels in the image to produce the output filtered image. Try this code and check the result:
 ::
 
     import cv2
@@ -48,20 +48,20 @@ Result:
 Image Blurring (Image Smoothing)
 ==================================
 
-Image blurring is achieved by convolving the image with a low-pass filter kernel. It is useful for removing noises. It actually removes high frequency content (eg: noise, edges) from the image. So edges are blurred a little bit in this operation. (Well, there are blurring techniques which doesn't blur the edges too). OpenCV provides mainly four types of blurring techniques.
+Image blurring is achieved by convolving the image with a low-pass filter kernel. It is useful for removing noise. It actually removes high frequency content (e.g: noise, edges) from the image resulting in edges being blurred when this is filter is applied. (Well, there are blurring techniques which do not blur edges). OpenCV provides mainly four types of blurring techniques.
 
 1. Averaging
 --------------
 
-This is done by convolving image with a normalized box filter. It simply takes the average of all the pixels under kernel area and replace the central element. This is done by the function **cv2.blur()** or **cv2.boxFilter()**. Check the docs for more details about the kernel. We should specify the width and height of kernel. A 3x3 normalized box filter would look like below:
+This is done by convolving the image with a normalized box filter. It simply takes the average of all the pixels under kernel area and replaces the central element with this average. This is done by the function **cv2.blur()** or **cv2.boxFilter()**. Check the docs for more details about the kernel. We should specify the width and height of kernel. A 3x3 normalized box filter would look like this:
 
 .. math::
 
         K =  \frac{1}{9} \begin{bmatrix} 1 & 1 & 1  \\ 1 & 1 & 1 \\ 1 & 1 & 1 \end{bmatrix}
 
-.. note:: If you don't want to use normalized box filter, use **cv2.boxFilter()**. Pass an argument ``normalize=False`` to the function.
+.. note:: If you don't want to use a normalized box filter, use **cv2.boxFilter()** and pass the argument ``normalize=False`` to the function.
 
-Check a sample demo below with a kernel of 5x5 size:
+Check the sample demo below with a kernel of 5x5 size:
 ::
 
     import cv2
@@ -85,10 +85,10 @@ Result:
         :align: center
 
 
-2. Gaussian Blurring
+2. Gaussian Filtering
 ----------------------
 
-In this, instead of box filter, gaussian kernel is used. It is done with the function, **cv2.GaussianBlur()**. We should specify the width and height of kernel which should be positive and odd. We also should specify the standard deviation in X and Y direction, sigmaX and sigmaY respectively. If only sigmaX is specified, sigmaY is taken as same as sigmaX. If both are given as zeros, they are calculated from kernel size. Gaussian blurring is highly effective in removing gaussian noise from the image.
+In this approach, instead of a box filter consisting of equal filter coefficients, a Gaussian kernel is used. It is done with the function, **cv2.GaussianBlur()**. We should specify the width and height of the kernel which should be positive and odd. We also should specify the standard deviation in the X and Y directions, sigmaX and sigmaY respectively. If only sigmaX is specified, sigmaY is taken as equal to sigmaX. If both are given as zeros, they are calculated from the kernel size. Gaussian filtering is highly effective in removing Gaussian noise from the image.
 
 If you want, you can create a Gaussian kernel with the function, **cv2.getGaussianKernel()**.
 
@@ -105,12 +105,12 @@ Result:
         :align: center
 
 
-3. Median Blurring
+3. Median Filtering
 --------------------
 
-Here, the function **cv2.medianBlur()** takes median of all the pixels under kernel area and central element is replaced with this median value. This is highly effective against salt-and-pepper noise in the images. Interesting thing is that, in the above filters, central element is a newly calculated value which may be a pixel value in the image or a new value. But in median blurring, central element is always replaced by some pixel value in the image. It reduces the noise effectively. Its kernel size should be a positive odd integer.
+Here, the function **cv2.medianBlur()** computes the median of all the pixels under the kernel window and the central pixel is replaced with this median value. This is highly effective in removing salt-and-pepper noise. One interesting thing to note is that, in the Gaussian and box filters, the filtered value for the central element can be a value which may not exist in the original image. However this is not the case in median filtering, since the central element is always replaced by some pixel value in the image. This reduces the noise effectively. The kernel size must be a positive odd integer.
 
-In this demo, I added a 50% noise to our original image and applied median blur. Check the result:
+In this demo, we add a 50% noise to our original image and use a median filter. Check the result:
 ::
 
     median = cv2.medianBlur(img,5)
@@ -125,11 +125,11 @@ Result:
 4. Bilateral Filtering
 -----------------------
 
-**cv2.bilateralFilter()** is highly effective in noise removal while keeping edges sharp. But the operation is slower compared to other filters. We already saw that gaussian filter takes the a neighbourhood around the pixel and find its gaussian weighted average. This gaussian filter is a function of space alone, that is, nearby pixels are considered while filtering. It doesn't consider whether pixels have almost same intensity. It doesn't consider whether pixel is an edge pixel or not. So it blurs the edges also, which we don't want to do. 
+As we noted, the filters we presented earlier tend to blur edges. This is not the case for the bilateral filter, **cv2.bilateralFilter()**, which was defined for, and is highly effective at noise removal while preserving edges. But the operation is slower compared to other filters. We already saw that a Gaussian filter takes the a neighborhood around the pixel and finds its Gaussian weighted average. This Gaussian filter is a function of space alone, that is, nearby pixels are considered while filtering. It does not consider whether pixels have almost the same intensity value and does not consider whether the pixel lies on an edge or not. The resulting effect is that Gaussian filters tend to blur edges, which is undesirable. 
 
-Bilateral filter also takes a gaussian filter in space, but one more gaussian filter which is a function of pixel difference. Gaussian function of space make sure only nearby pixels are considered for blurring while gaussian function of intensity difference make sure only those pixels with similar intensity to central pixel is considered for blurring. So it preserves the edges since pixels at edges will have large intensity variation.
+The bilateral filter also uses a Gaussian filter in the space domain, but it also uses one more (multiplicative) Gaussian filter component which is a function of pixel intensity differences. The Gaussian function of space makes sure that only pixels are 'spatial neighbors' are considered for filtering, while the Gaussian component applied in the intensity domain (a Gaussian function of intensity differences) ensures that only those pixels with intensities similar to that of the central pixel ('intensity neighbors') are included to compute the blurred intensity value. As a result, this method preserves edges, since for pixels lying near edges, neighboring pixels placed on the other side of the edge, and therefore exhibiting large intensity variations when compared to the central pixel, will not be included for blurring.
 
-Below samples shows use bilateral filter (For details on arguments, visit docs).
+The sample below demonstrates the use of bilateral filtering (For details on arguments, see the OpenCV docs).
 ::
 
     blur = cv2.bilateralFilter(img,9,75,75)
@@ -140,12 +140,14 @@ Result:
         :alt: Bilateral Filtering
         :align: center    
 
-See, the texture on the surface is gone, but edges are still preserved.
+Note that the texture on the surface is gone, but edges are still preserved.
 
 Additional Resources
 ======================
 
-1. Details about the `bilateral filtering <http://people.csail.mit.edu/sparis/bf_course/>`_
+1. Details about the `bilateral filtering can be found at <http://people.csail.mit.edu/sparis/bf_course/>`_
 
 Exercises
 ===========
+
+Take an image, add Gaussian noise and salt and pepper noise, compare the effect of blurring via box, Gaussian, median and bilateral filters for both noisy images, as you change the level of noise.


### PR DESCRIPTION
Made editing fixes, grammar, capitalization, etc.
rephrased some sentences that were ambiguous (to me)

Also this statement is not really correct "Gaussian filtering is highly effective in removing Gaussian noise from the image.": the main goal of the Gaussian filter is to attenuate the influence of pixels that are further away from the central pixel, when compared to pixels that are immediately adjacent, and do this 'smoothly', i.e. use filter coefficients that fall off to zero smoothy. The Gaussian effect is in the spatial domain. On the other hand, if you are talking about Gaussian noise, you are talking about the intensity domain. Different things like you explained in the bilateral filter... One of the nice features of Gaussian vs. box filter is that b/c of the abrupt falloff of the box filter coefficient in the spatial domain (effectively the box filter is a step function in 2D) we will get Gibbs effects, therefore aliasing. (indeed the Fourier transform of a step function filter is a sinc function, and the ripples in the sinc are what causes  aliasing). By contrast the Fourier transform of a Gaussian is also a Gaussian, 
therefore no ripples, no Gibbs effects, a nice and clean low pass in the frequency domain..

In sum I would just remove that sentence.

Btw, this tutorial is really a great ressource! Thanks for putting it together and making it available. Awesome work. We are going to use it in our class at JHU and will encourage students to submit back errata.
