### PR TITLE
Update py_drawing_functions.rst

### DIFF
--- a/source/py_tutorials/py_gui/py_drawing_functions/py_drawing_functions.rst
+++ b/source/py_tutorials/py_gui/py_drawing_functions/py_drawing_functions.rst
@@ -33,21 +33,21 @@ To draw a line, you need to pass starting and ending coordinates of line. We wil
     img = np.zeros((512,512,3), np.uint8)
     
     # Draw a diagonal blue line with thickness of 5 px
-    img = cv2.line(img,(0,0),(511,511),(255,0,0),5)
+    cv2.line(img,(0,0),(511,511),(255,0,0),5)
 
 Drawing Rectangle
 -------------------
 To draw a rectangle, you need top-left corner and bottom-right corner of rectangle. This time we will draw a green rectangle at the top-right corner of image.
 ::
     
-    img = cv2.rectangle(img,(384,0),(510,128),(0,255,0),3)
+    cv2.rectangle(img,(384,0),(510,128),(0,255,0),3)
     
 Drawing Circle
 ----------------
 To draw a circle, you need its center coordinates and radius. We will draw a circle inside the rectangle drawn above.
 ::
 
-    img = cv2.circle(img,(447,63), 63, (0,0,255), -1)
+       cv2.circle(img,(447,63), 63, (0,0,255), -1)
     
 Drawing Ellipse
 --------------------
@@ -55,7 +55,7 @@ Drawing Ellipse
 To draw the ellipse, we need to pass several arguments. One argument is the center location (x,y). Next argument is axes lengths (major axis length, minor axis length). ``angle`` is the angle of rotation of ellipse in anti-clockwise direction. ``startAngle`` and ``endAngle`` denotes the starting and ending of ellipse arc measured in clockwise direction from major axis. i.e. giving values 0 and 360 gives the full ellipse. For more details, check the documentation of **cv2.ellipse()**. Below example draws a half ellipse at the center of the image.
 ::
 
-    img = cv2.ellipse(img,(256,256),(100,50),0,0,180,255,-1) 
+    cv2.ellipse(img,(256,256),(100,50),0,0,180,255,-1) 
 
 
 Drawing Polygon
@@ -65,7 +65,7 @@ To draw a polygon, first you need coordinates of vertices. Make those points int
 
     pts = np.array([[10,5],[20,30],[70,20],[50,10]], np.int32)
     pts = pts.reshape((-1,1,2))
-    img = cv2.polylines(img,[pts],True,(0,255,255))
+    cv2.polylines(img,[pts],True,(0,255,255))
     
 .. Note:: If third argument is ``False``, you will get a polylines joining all the points, not a closed shape.
 


### PR DESCRIPTION
Hello,

cv2.line(), cv2.rectangle(), etc funtion returns None. In that case the img variable being assigned becomes None. As in python the 'img' parameter are passed by reference there is no need to assign the return of the function. 

The following is a working code in python. 

'''
Created on 23-Feb-2014

@author: niraj
'''
import numpy as np
import cv2

img = np.zeros((512,512,3), np.uint8)
cv2.line(img,(0,0),(511,511),(255,0,0),5)
cv2.rectangle(img,(384,0),(510,128),(0,255,0),3)
cv2.circle(img,(447,63), 63, (0,0,255), -1)
cv2.ellipse(img,(256,256),(100,50),0,0,180,255,-1) 
pts = np.array([[10,5],[20,30],[70,20],[50,10]], np.int32)
pts = pts.reshape((-1,1,2))
cv2.polylines(img,[pts],True,(0,255,255))
font = cv2.FONT_HERSHEY_SIMPLEX
cv2.putText(img,'OpenCV',(10,500), font, 4,(255,255,255),2)

cv2.imshow('image', img)

cv2.waitKey(0)
cv2.destroyAllWindows()
