### PR TITLE
Correct the implementation of HOUGH_GRADIENT

### DIFF
--- a/source/py_tutorials/py_imgproc/py_houghcircles/py_houghcircles.rst
+++ b/source/py_tutorials/py_imgproc/py_houghcircles/py_houghcircles.rst
@@ -25,7 +25,7 @@ The function we use here is **cv2.HoughCircles()**. It has plenty of arguments w
     img = cv2.medianBlur(img,5)
     cimg = cv2.cvtColor(img,cv2.COLOR_GRAY2BGR)
 
-    circles = cv2.HoughCircles(img,cv2.HOUGH_GRADIENT,1,20,
+    circles = cv2.HoughCircles(img,cv2.cv.CV_HOUGH_GRADIENT,1,20,
                                 param1=50,param2=30,minRadius=0,maxRadius=0)
 
     circles = np.uint16(np.around(circles))


### PR DESCRIPTION
cv2.HOUGH_GRADIENT throws a 'module' object has no attribute 'HOUGH_GRADIENT' error.
