### PR TITLE
Corrected a typo in gradient tutorial

### DIFF
--- a/source/py_tutorials/py_imgproc/py_gradients/py_gradients.rst
+++ b/source/py_tutorials/py_imgproc/py_gradients/py_gradients.rst
@@ -42,9 +42,9 @@ Below code shows all operators in a single diagram. All kernels are of 5x5 size.
 
     img = cv2.imread('dave.jpg',0)
 
-    laplacian = cv2.Laplacian(img,cv2.CV_64F)
-    sobelx = cv2.Sobel(img,cv2.CV_64F,1,0,ksize=5)
-    sobely = cv2.Sobel(img,cv2.CV_64F,0,1,ksize=5)
+    laplacian = cv2.Laplacian(img,cv2.CV_8U)
+    sobelx = cv2.Sobel(img,cv2.CV_8U,1,0,ksize=5)
+    sobely = cv2.Sobel(img,cv2.CV_8U,0,1,ksize=5)
 
     plt.subplot(2,2,1),plt.imshow(img,cmap = 'gray')
     plt.title('Original'), plt.xticks([]), plt.yticks([])


### PR DESCRIPTION
The image output in the first code example should have been in CV_8U
