### PR TITLE
canny: fix typo on argument description

### DIFF
--- a/source/py_tutorials/py_imgproc/py_canny/py_canny.rst
+++ b/source/py_tutorials/py_imgproc/py_canny/py_canny.rst
@@ -61,7 +61,7 @@ So what we finally get is strong edges in the image.
 Canny Edge Detection in OpenCV
 ===============================
 
-OpenCV puts all the above in single function, **cv2.Canny()**. We will see how to use it. First argument is our input image. Second and third arguments are our `minVal` and `maxVal` respectively. Third argument is `aperture_size`. It is the size of Sobel kernel used for find image gradients. By default it is 3. Last argument is `L2gradient` which specifies the equation for finding gradient magnitude. If it is ``True``, it uses the equation mentioned above which is more accurate, otherwise it uses this function: :math:`Edge\_Gradient \; (G) = |G_x| + |G_y|`. By default, it is ``False``.
+OpenCV puts all the above in single function, **cv2.Canny()**. We will see how to use it. First argument is our input image. Second and third arguments are our `minVal` and `maxVal` respectively. Fourth argument is `aperture_size`. It is the size of Sobel kernel used to find image gradients. By default it is 3. Last argument is `L2gradient` which specifies the equation for finding gradient magnitude. If it is ``True``, it uses the equation mentioned above which is more accurate, otherwise it uses this function: :math:`Edge\_Gradient \; (G) = |G_x| + |G_y|`. By default, it is ``False``.
 ::
 
     import cv2


### PR DESCRIPTION
fixed tiny typo on argument counting in canny description.
Changed 'Third' with 'Fourth'.
Changed 'used for find' with 'used to find'
