### PR TITLE
Update py_colorspaces.rst

### DIFF
--- a/source/py_tutorials/py_imgproc/py_colorspaces/py_colorspaces.rst
+++ b/source/py_tutorials/py_imgproc/py_colorspaces/py_colorspaces.rst
@@ -54,8 +54,8 @@ Below is the code which are commented in detail :
         hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
         
         # define range of blue color in HSV
-        lower_blue = np.array([110,50,50])
-        upper_blue = np.array([130,255,255])
+        lower_blue = np.array([110, 50, 50], dtype=np.uint8)
+        upper_blue = np.array([130,255,255], dtype=np.uint8)
         
         # Threshold the HSV image to get only blue colors
         mask = cv2.inRange(hsv, lower_blue, upper_blue)


### PR DESCRIPTION
The following error message is displayed without the correction : "The lower bounary is neither an array of the same size and same type as src", and the demo. stops.
