### PR TITLE
Update py_matcher.rst

### DIFF
--- a/source/py_tutorials/py_feature2d/py_matcher/py_matcher.rst
+++ b/source/py_tutorials/py_feature2d/py_matcher/py_matcher.rst
@@ -43,10 +43,10 @@ We are using SIFT descriptors to match features. So let's start with loading ima
     img1 = cv2.imread('box.png',0)          # queryImage
     img2 = cv2.imread('box_in_scene.png',0) # trainImage
 
-    # Initiate SIFT detector
+    # Initiate ORB detector
     orb = cv2.ORB()
 
-    # find the keypoints and descriptors with SIFT
+    # find the keypoints and descriptors with ORB
     kp1, des1 = orb.detectAndCompute(img1,None)
     kp2, des2 = orb.detectAndCompute(img2,None)
 


### PR DESCRIPTION
Documentation says code uses SIFT, but ORB is used
ORB does not have the patent restrictions that SIFT carries
