### PR TITLE
fix usage of drawChessboardCorners

### DIFF
--- a/source/py_tutorials/py_calib3d/py_calibration/py_calibration.rst
+++ b/source/py_tutorials/py_calib3d/py_calibration/py_calibration.rst
@@ -114,7 +114,7 @@ Once we find the corners, we can increase their accuracy using **cv2.cornerSubPi
             imgpoints.append(corners2)
             
             # Draw and display the corners
-            img = cv2.drawChessboardCorners(img, (7,6), corners2,ret)
+            cv2.drawChessboardCorners(img, (7,6), corners2,ret)
             cv2.imshow('img',img)
             cv2.waitKey(500)
 


### PR DESCRIPTION
`drawChessboardCorners` operates in-place and [returns None](http://docs.opencv.org/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html#cv2.drawChessboardCorners). the current code leads to errors such as: `error: (-215) size.width>0 && size.height>0 in function cv::imshow`
