### PR TITLE
change variable name im to img for consistency

### DIFF
--- a/source/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.rst
+++ b/source/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.rst
@@ -25,8 +25,8 @@ Let's see how to find contours of a binary image:
     import numpy as np
     import cv2
      
-    im = cv2.imread('test.jpg')
-    imgray = cv2.cvtColor(im,cv2.COLOR_BGR2GRAY)
+    img = cv2.imread('test.jpg')
+    imgray = cv2.cvtColor(img,cv2.COLOR_BGR2GRAY)
     ret,thresh = cv2.threshold(imgray,127,255,0)
     image, contours, hierarchy = cv2.findContours(thresh,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
 


### PR DESCRIPTION
Using the variable name `img` instead of `im` (regarding the representation of the original image to be processed) I believe will ensure consistency - and ensuring the downstream code to work with reduced frastration from the student's perspective.

For instance, the `cv2.drawContours()` procedure downstream overlay `contours` to `img` (not `im`). 

Keeping the variable name as `img` (instead of `im`) will ensure the `cv2.drawContours()` step downstream to run smoothly. (The student also get to see immediately that we are trying to overlay the `contours` to the original image to be processed - rather than some random / abstract images.)
