### PR TITLE
Update py_image_arithmetics.rst

### DIFF
--- a/source/py_tutorials/py_core/py_image_arithmetics/py_image_arithmetics.rst
+++ b/source/py_tutorials/py_core/py_image_arithmetics/py_image_arithmetics.rst
@@ -83,14 +83,14 @@ I want to put OpenCV logo above an image. If I add two images, it will change co
 
     # Now create a mask of logo and create its inverse mask also
     img2gray = cv2.cvtColor(img2,cv2.COLOR_BGR2GRAY)
-    ret, mask = cv2.threshold(img2gray, 10, 255, cv2.THRESH_BINARY)
+    ret, mask = cv2.threshold(img2gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU) # This makes all the areas of the logo black
     mask_inv = cv2.bitwise_not(mask)
 
     # Now black-out the area of logo in ROI
-    img1_bg = cv2.bitwise_and(roi,roi,mask = mask_inv)
+    img1_bg = cv2.bitwise_and(roi,roi,mask = mask)
 
     # Take only region of logo from logo image.
-    img2_fg = cv2.bitwise_and(img2,img2,mask = mask)
+    img2_fg = cv2.bitwise_and(img2,img2,mask = mask_inv)
 
     # Put logo in ROI and modify the main image
     dst = cv2.add(img1_bg,img2_fg)


### PR DESCRIPTION
Under Bitwise Operations
The original program outputted the image with a white box containing the openCV logo. Changes are
1) The thresh holding returned a binary image of only the "openCV" text. Using cv2.THRESH_OTSU ensures the entire logo is present in the binary image.
2) "img1_bg" had the ROI image black in all parts except the logo. Using "mask" instead of "mask_inv" fixed it. It now blacks out the logo area.
3) "img2_fg" had the image blacked out where the logo was present. Using "mask_inv" instead of "mask" fixed it. It now holds the logo.
