### PR TITLE
Added chess_size

### DIFF
--- a/source/py_tutorials/py_calib3d/py_calibration/py_calibration.rst
+++ b/source/py_tutorials/py_calib3d/py_calibration/py_calibration.rst
@@ -89,9 +89,12 @@ Once we find the corners, we can increase their accuracy using **cv2.cornerSubPi
     # termination criteria
     criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 30, 0.001)
 
+    # chessboard size
+    chess_size = (6,7)
+    
     # prepare object points, like (0,0,0), (1,0,0), (2,0,0) ....,(6,5,0)
-    objp = np.zeros((6*7,3), np.float32)
-    objp[:,:2] = np.mgrid[0:7,0:6].T.reshape(-1,2)
+    objp = np.zeros( (np.prod(chess_size), 3), np.float32)
+    objp[:,:2] = np.indices(chess_size).T.reshape(-1, 2)
 
     # Arrays to store object points and image points from all the images.
     objpoints = [] # 3d point in real world space
@@ -104,7 +107,7 @@ Once we find the corners, we can increase their accuracy using **cv2.cornerSubPi
         gray = cv2.cvtColor(img,cv2.COLOR_BGR2GRAY)
 
         # Find the chess board corners    
-        ret, corners = cv2.findChessboardCorners(gray, (7,6),None)
+        ret, corners = cv2.findChessboardCorners(gray, chess_size,None)
 
         # If found, add object points, image points (after refining them)
         if ret == True:
@@ -114,7 +117,7 @@ Once we find the corners, we can increase their accuracy using **cv2.cornerSubPi
             imgpoints.append(corners2)
             
             # Draw and display the corners
-            img = cv2.drawChessboardCorners(img, (7,6), corners2,ret)
+            img = cv2.drawChessboardCorners(img, chess_size, corners2,ret)
             cv2.imshow('img',img)
             cv2.waitKey(500)
 


### PR DESCRIPTION
Added chess_size because it's easier to understand when running cv2.findChessboardCorners() and cv2.drawChessboardCorners(). Also, the way objects points are prepared is a bit confusing when using a chessboard of a different size other than one in the tutorial. Adding chess_size fixes the problem.
