### PR TITLE
Update py_lucas_kanade.rst

### DIFF
--- a/source/py_tutorials/py_video/py_lucas_kanade/py_lucas_kanade.rst
+++ b/source/py_tutorials/py_video/py_lucas_kanade/py_lucas_kanade.rst
@@ -127,8 +127,8 @@ OpenCV provides all these in a single function, **cv2.calcOpticalFlowPyrLK()**. 
         for i,(new,old) in enumerate(zip(good_new,good_old)):
             a,b = new.ravel()
             c,d = old.ravel()
-            mask = cv2.line(mask, (a,b),(c,d), color[i].tolist(), 2)
-            frame = cv2.circle(frame,(a,b),5,color[i].tolist(),-1)
+            cv2.line(mask, (a,b),(c,d), color[i].tolist(), 2)
+            cv2.circle(frame,(a,b),5,color[i].tolist(),-1)
         img = cv2.add(frame,mask)
 
         cv2.imshow('frame',img)


### PR DESCRIPTION
There are typos on lines 130/131. The cv2.line and cv2.circle methods return None, and modify the first argument inputs instead, so mask and frame shouldn't be set to the output of cv2.line and cv2.circle.
