### PR TITLE
Updated py_contours_begin

### DIFF
--- a/source/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.rst
+++ b/source/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.rst
@@ -28,7 +28,7 @@ Let's see how to find contours of a binary image:
     im = cv2.imread('test.jpg')
     imgray = cv2.cvtColor(im,cv2.COLOR_BGR2GRAY)
     ret,thresh = cv2.threshold(imgray,127,255,0)
-    image, contours, hierarchy = cv2.findContours(thresh,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
+    contours, hierarchy = cv2.findContours(thresh,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
 
 See, there are three arguments in **cv2.findContours()** function, first one is source image, second is contour retrieval mode, third is contour approximation method. And it outputs the image, contours and hierarchy. ``contours`` is a Python list of all the contours in the image. Each individual contour is a Numpy array of (x,y) coordinates of boundary points of the object.
 


### PR DESCRIPTION
`cv2.findContours` returns a tuple with 2 values as the earlier one causes error.
