### PR TITLE
add available codec for OSX

### DIFF
--- a/source/py_tutorials/py_gui/py_video_display/py_video_display.rst
+++ b/source/py_tutorials/py_gui/py_video_display/py_video_display.rst
@@ -89,7 +89,7 @@ This time we create a **VideoWriter** object. We should specify the output file 
 
 * In Fedora: DIVX, XVID, MJPG, X264, WMV1, WMV2. (XVID is more preferable. MJPG results in high size video. X264 gives very small size video)
 * In Windows: DIVX (More to be tested and added)
-* In OSX : *(I don't have access to OSX. Can some one fill this?)*
+* In OSX: MP4V (Tested on OpenCV 3.1.0 and OSX 10.10.5)
 
 FourCC code is passed as ``cv2.VideoWriter_fourcc('M','J','P','G')`` or ``cv2.VideoWriter_fourcc(*'MJPG)`` for MJPG.
 


### PR DESCRIPTION
Spent a lot of time to figure this out. 

Sample code:

```
    cap = cv2.VideoCapture(0)
    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))

    fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
    out = cv2.VideoWriter(filename,fourcc, fps, ((width,height)))
    if not out:
        print ("!!! Failed VideoWriter: invalid parameters")
        sys.exit(1)

    while(cap.isOpened()):
      ret, frame = cap.read()
      if ret==True:
          frame = cv2.flip(frame,1)
          out.write(frame)
```
