### PR TITLE
Update py_meanshift.rst

### DIFF
--- a/source/py_tutorials/py_video/py_meanshift/py_meanshift.rst
+++ b/source/py_tutorials/py_video/py_meanshift/py_meanshift.rst
@@ -127,7 +127,7 @@ It is almost same as meanshift, but it returns a rotated rectangle (that is our 
 
     # set up the ROI for tracking
     roi = frame[r:r+h, c:c+w]
-    hsv_roi =  cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+    hsv_roi =  cv2.cvtColor(roi, cv2.COLOR_BGR2HSV)
     mask = cv2.inRange(hsv_roi, np.array((0., 60.,32.)), np.array((180.,255.,255.)))
     roi_hist = cv2.calcHist([hsv_roi],[0],mask,[180],[0,180])
     cv2.normalize(roi_hist,roi_hist,0,255,cv2.NORM_MINMAX)


### PR DESCRIPTION
Similar as the code in meanshift, there is a same typo in the code of camshift: it should be **roi** instead of **frame**
