### PR TITLE
Update py_drawing_functions.rst

### DIFF
--- a/source/py_tutorials/py_gui/py_drawing_functions/py_drawing_functions.rst
+++ b/source/py_tutorials/py_gui/py_drawing_functions/py_drawing_functions.rst
@@ -33,29 +33,31 @@ To draw a line, you need to pass starting and ending coordinates of line. We wil
     img = np.zeros((512,512,3), np.uint8)
     
     # Draw a diagonal blue line with thickness of 5 px
-    img = cv2.line(img,(0,0),(511,511),(255,0,0),5)
+    cv2.line(img,(0,0),(511,511),(255,0,0),5)
+
+.. Note:: **cv2.line()** and the other drawing functions described in this section are in-place functions. This means that they directly modify the image passed in the first argument. The functions return ``None``, so there is no need to store the results of the function calls.
 
 Drawing Rectangle
 -------------------
 To draw a rectangle, you need top-left corner and bottom-right corner of rectangle. This time we will draw a green rectangle at the top-right corner of image.
 ::
     
-    img = cv2.rectangle(img,(384,0),(510,128),(0,255,0),3)
+    cv2.rectangle(img,(384,0),(510,128),(0,255,0),3)
     
 Drawing Circle
 ----------------
 To draw a circle, you need its center coordinates and radius. We will draw a circle inside the rectangle drawn above.
 ::
 
-    img = cv2.circle(img,(447,63), 63, (0,0,255), -1)
+    cv2.circle(img,(447,63), 63, (0,0,255), -1)
     
 Drawing Ellipse
 --------------------
 
-To draw the ellipse, we need to pass several arguments. One argument is the center location (x,y). Next argument is axes lengths (major axis length, minor axis length). ``angle`` is the angle of rotation of ellipse in anti-clockwise direction. ``startAngle`` and ``endAngle`` denotes the starting and ending of ellipse arc measured in clockwise direction from major axis. i.e. giving values 0 and 360 gives the full ellipse. For more details, check the documentation of **cv2.ellipse()**. Below example draws a half ellipse at the center of the image.
+To draw the ellipse, we need to pass several arguments. One argument is the center location (x,y). Next argument is axes lengths (major axis length, minor axis length). ``angle`` is the angle of rotation of ellipse in anti-clockwise direction. ``startAngle`` and ``endAngle`` denotes the starting and ending of ellipse arc measured in clockwise direction from major axis. i.e. giving values 0 and 360 gives the full ellipse. For more details, check the documentation of `cv2.ellipse() <http://docs.opencv.org/2.4/modules/core/doc/drawing_functions.html#ellipse>`_. Below example draws a half ellipse at the center of the image.
 ::
 
-    img = cv2.ellipse(img,(256,256),(100,50),0,0,180,255,-1) 
+    cv2.ellipse(img,(256,256),(100,50),0,0,180,255,-1) 
 
 
 Drawing Polygon
@@ -65,7 +67,7 @@ To draw a polygon, first you need coordinates of vertices. Make those points int
 
     pts = np.array([[10,5],[20,30],[70,20],[50,10]], np.int32)
     pts = pts.reshape((-1,1,2))
-    img = cv2.polylines(img,[pts],True,(0,255,255))
+    cv2.polylines(img,[pts],True,(0,255,255))
     
 .. Note:: If third argument is ``False``, you will get a polylines joining all the points, not a closed shape.
 
@@ -76,7 +78,7 @@ Adding Text to Images:
 To put texts in images, you need specify following things. 
     * Text data that you want to write
     * Position coordinates of where you want put it (i.e. bottom-left corner where data starts).
-    * Font type (Check **cv2.putText()** docs for supported fonts)
+    * Font type (Check `cv2.putText() <http://docs.opencv.org/2.4/modules/core/doc/drawing_functions.html#puttext>`_ docs for supported fonts)
     * Font Scale (specifies the size of font)
     * regular things like color, thickness, lineType etc. For better look, ``lineType = cv2.LINE_AA`` is recommended.
     


### PR DESCRIPTION
In the most recent version of OpenCV, drawing operations are performed in-place, and return `None`

If the result is assigned to `img` then it cannot be displayed with `cv2.imshow()`, which is confusing when working through the tutorial for the first time.
