### PR TITLE
4. RETR_TREE: Mistake in the corresponding image

### DIFF
--- a/source/py_tutorials/py_imgproc/py_contours/py_contours_hierarchy/py_contours_hierarchy.rst
+++ b/source/py_tutorials/py_imgproc/py_contours/py_contours_hierarchy/py_contours_hierarchy.rst
@@ -156,6 +156,8 @@ Take contour-0 : It is in hierarchy-0. Next contour in same hierarchy is contour
 
 Take contour-2 : It is in hierarchy-1. No contour in same level. No previous one. Child is contour-2. Parent is contour-0. So array is [-1,-1,2,0].
 
+**NOTE:** There is a mistake in that picture. The hierarchy of contour-6 should be (5) instead of (6), since contour-6 is not a child of contour-5, but of contour-4. Though, the following array of hierarchy states is correct.
+
 And remaining, try yourself. Below is the full answer:
 ::
 


### PR DESCRIPTION
Hi,

In my eyes, the hierarchy of contour-6 should be (5) instead of (6), since contour-6 is not a child of contour-5, but of contour-4.
The following array of hierarchy states the same, thus it seems to be correct:

array([[[ 7, -1,  1, -1],
        [-1, -1,  2,  0],
        [-1, -1,  3,  1],
        [-1, -1,  4,  2],
        [-1, -1,  5,  3],
        [ 6, -1, -1,  4],
    -> [-1,  5, -1,  4],
        [ 8,  0, -1, -1],
        [-1,  7, -1, -1]]])

Nevertheless, great tutorials! They are very useful :)

Thanks and best regards,
Patrick
