### PR TITLE
Note for multiprocessing users

### DIFF
--- a/source/py_tutorials/py_gui/py_video_display/py_video_display.rst
+++ b/source/py_tutorials/py_gui/py_video_display/py_video_display.rst
@@ -76,6 +76,7 @@ It is same as capturing from Camera, just change camera index with video file na
     cv2.destroyAllWindows()
     
 .. Note:: Make sure proper versions of ffmpeg or gstreamer is installed. Sometimes, it is a headache to work with Video Capture mostly due to wrong installation of ffmpeg/gstreamer.
+.. Note:: If you want to use pythons multiprocessing, make sure to create the VideoCapture object in the same process where you execute the read function - otherwise read might hang.
 
 
 Saving a Video


### PR DESCRIPTION
Read hangs if the VideoCapture object was created outside the process that uses read()
