### PR TITLE
Corrected 2nd example of code for houghLines

### DIFF
--- a/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
+++ b/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
@@ -92,19 +92,26 @@ OpenCV implementation is based on Robust Detection of Lines Using the Progressiv
 Best thing is that, it directly returns the two endpoints of lines. In previous case, you got only the parameters of lines, and you had to find all the points. Here, everything is direct and simple.
 ::
 
-    import cv2
-    import numpy as np
-
-    img = cv2.imread('dave.jpg')
-    gray = cv2.cvtColor(img,cv2.COLOR_BGR2GRAY)
-    edges = cv2.Canny(gray,50,150,apertureSize = 3)
-    minLineLength = 100
-    maxLineGap = 10
-    lines = cv2.HoughLinesP(edges,1,np.pi/180,100,minLineLength,maxLineGap)
-    for x1,y1,x2,y2 in lines[0]:
-        cv2.line(img,(x1,y1),(x2,y2),(0,255,0),2)
-
-    cv2.imwrite('houghlines5.jpg',img)       
+      import cv2
+      import numpy as np
+      
+      img = cv2.imread('dave.jpg')
+      gray = cv2.cvtColor(img,cv2.COLOR_BGR2GRAY)
+      
+      
+      edges = cv2.Canny(gray,100,200,apertureSize = 3)
+      cv2.imshow('edges',edges)
+      cv2.waitKey(0)
+      
+      minLineLength = 30
+      maxLineGap = 10
+      lines = cv2.HoughLinesP(edges,1,np.pi/180,15,minLineLength,maxLineGap)
+      for x in range(0, len(lines)):
+          for x1,y1,x2,y2 in lines[x]:
+              cv2.line(img,(x1,y1),(x2,y2),(0,255,0),2)
+      
+      cv2.imshow('hough',img)
+      cv2.waitKey(0)     
 
 See the results below:
 


### PR DESCRIPTION
The code example only shows the first hough line.

In case you want to print all the hough lines on an image you have to print all lines.

This is the corrected code:
