### PR TITLE
I believe that the sin value should be negative

### DIFF
--- a/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
+++ b/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
@@ -58,7 +58,7 @@ Everything explained above is encapsulated in the OpenCV function, **cv2.HoughLi
     lines = cv2.HoughLines(edges,1,np.pi/180,200)
     for rho,theta in lines[0]:
         a = np.cos(theta)
-        b = np.sin(theta)
+        b = -np.sin(theta)
         x0 = a*rho
         y0 = b*rho
         x1 = int(x0 + 1000*(-b))   


### PR DESCRIPTION
I am in a class where we implemented HoughLines by hand, while the above works fine for normal retangular and reflective images, it didn't work well with things like a triangle or in the case of trying to recognize other objects that are lines. I know a lot of people from this class have been using this section of code for their line drawing, and it's an unnecessary pain (in my opinion) so I'd like to propose changing it, what do you think?
