### PR TITLE
Fix variable assignment problem with face detection example, and broken links.

### DIFF
--- a/data/readme.txt
+++ b/data/readme.txt
@@ -13,7 +13,7 @@ messi5.jpg
 left.jpg
 right.jpg
 
-Feature Matching	-	https://github.com/Itseez/opencv/blob/master/samples/c/box.png
-			-	https://github.com/Itseez/opencv/blob/master/samples/c/box_in_scene.png
+Feature Matching	-	https://github.com/opencv/opencv/blob/master/samples/data/box.png
+			-	https://github.com/opencv/opencv/blob/master/samples/data/box_in_scene.png
 
-Background subtraction	-	https://github.com/Itseez/opencv/blob/master/samples/gpu/768x576.avi
+Background subtraction	-	https://github.com/npinto/opencv/blob/master/samples/gpu/768x576.avi

--- a/source/py_tutorials/py_objdetect/py_face_detection/py_face_detection.rst
+++ b/source/py_tutorials/py_objdetect/py_face_detection/py_face_detection.rst
@@ -68,12 +68,12 @@ First we need to load the required XML classifiers. Then load our input image (o
     gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 
 
-Now we find the faces in the image. If faces are found, it returns the positions of detected faces as Rect(x,y,w,h). Once we get these locations, we can create a ROI for the face and apply eye detection on this ROI (since eyes are always on the face !!! ).
+Now we find the faces in the image. If faces are found, it returns the positions of detected faces as Rect(x,y,w,h). Once we get these locations, we can create a ROI for the face and apply eye detection on this ROI (since eyes are always on the face!).
 ::
 
     faces = face_cascade.detectMultiScale(gray, 1.3, 5)
     for (x,y,w,h) in faces:
-        img = cv2.rectangle(img,(x,y),(x+w,y+h),(255,0,0),2)
+        cv2.rectangle(img,(x,y),(x+w,y+h),(255,0,0),2)
         roi_gray = gray[y:y+h, x:x+w]
         roi_color = img[y:y+h, x:x+w]
         eyes = eye_cascade.detectMultiScale(roi_gray)


### PR DESCRIPTION
This commit fixes an error with [this face detection example](https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_objdetect/py_face_detection/py_face_detection.html#face-detection) in the OpenCV2 Python
tutorials. It currently assigns the result of a `cv2.rectangle()` call
to the variable `img`, which is supposed to contain the
image. The `cv2.rectangle()` call does not return anything,
so `img` is null, so the subsequent assignment of `roi_color` fails.

This fixes the problem by eliminating the variable assignment.