### PR TITLE
Fix broken links and broken references to samples/python2

### DIFF
--- a/source/py_tutorials/py_imgproc/py_histograms/py_2d_histogram/py_2d_histogram.rst
+++ b/source/py_tutorials/py_imgproc/py_histograms/py_2d_histogram/py_2d_histogram.rst
@@ -13,7 +13,7 @@ Introduction
 
 In the first article, we calculated and plotted one-dimensional histogram. It is called one-dimensional because we are taking only one feature into our consideration, ie grayscale intensity value of the pixel. But in two-dimensional histograms, you consider two features. Normally it is used for finding color histograms where two features are Hue & Saturation values of every pixel.
 
-There is a `python sample in the official samples <https://github.com/Itseez/opencv/blob/master/samples/python2/color_histogram.py>`_ already for finding color histograms. We will try to understand how to create such a color histogram, and it will be useful in understanding further topics like Histogram Back-Projection.
+There is a `python sample in the official samples <https://github.com/Itseez/opencv/blob/master/samples/python/color_histogram.py>`_ already for finding color histograms. We will try to understand how to create such a color histogram, and it will be useful in understanding further topics like Histogram Back-Projection.
 
 2D Histogram in OpenCV
 =======================
@@ -93,7 +93,7 @@ In histogram, you can see some high values near H = 100 and S = 200. It correspo
 Method 3 : OpenCV sample style !!
 ------------------------------------
 
-There is a `sample code for color-histogram in OpenCV-Python2 samples <https://github.com/Itseez/opencv/blob/master/samples/python2/color_histogram.py>`_. If you run the code, you can see the histogram shows the corresponding color also. Or simply it outputs a color coded histogram. Its result is very good (although you need to add extra bunch of lines).
+There is a `sample code for color-histogram in OpenCV-Python2 samples <https://github.com/Itseez/opencv/blob/master/samples/python/color_histogram.py>`_. If you run the code, you can see the histogram shows the corresponding color also. Or simply it outputs a color coded histogram. Its result is very good (although you need to add extra bunch of lines).
 
 In that code, the author created a color map in HSV. Then converted it into BGR. The resulting histogram image is multiplied with this color map. He also uses some preprocessing steps to remove small isolated pixels, resulting in a good histogram.
 

--- a/source/py_tutorials/py_imgproc/py_histograms/py_histogram_begins/py_histogram_begins.rst
+++ b/source/py_tutorials/py_imgproc/py_histograms/py_histogram_begins/py_histogram_begins.rst
@@ -127,7 +127,7 @@ You can deduct from the above graph that, blue has some high value areas in the 
 2. Using OpenCV
 --------------------------
 
-Well, here you adjust the values of histograms along with its bin values to look like x,y coordinates so that you can draw it using cv2.line() or cv2.polyline() function to generate same image as above. This is already available with OpenCV-Python2 official samples. `Check the Code <https://github.com/Itseez/opencv/raw/master/samples/python2/hist.py>`_
+Well, here you adjust the values of histograms along with its bin values to look like x,y coordinates so that you can draw it using cv2.line() or cv2.polyline() function to generate same image as above. This is already available with OpenCV-Python2 official samples. `Check the Code <https://github.com/Itseez/opencv/raw/master/samples/python/hist.py>`_
 
 Application of Mask
 =====================

--- a/source/py_tutorials/py_ml/py_knn/py_knn_opencv/py_knn_opencv.rst
+++ b/source/py_tutorials/py_ml/py_knn/py_knn_opencv/py_knn_opencv.rst
@@ -14,7 +14,7 @@ In this chapter
 OCR of Hand-written Digits
 ============================
 
-Our goal is to build an application which can read the handwritten digits. For this we need some train_data and test_data. OpenCV comes with an image `digits.png` (in the folder ``opencv/samples/python2/data/``) which has 5000 handwritten digits (500 for each digit). Each digit is a 20x20 image. So our first step is to split this image into 5000 different digits. For each digit, we flatten it into a single row with 400 pixels. That is our feature set, ie intensity values of all pixels. It is the simplest feature set we can create. We use first 250 samples of each digit as train_data, and next 250 samples as test_data. So let's prepare them first.
+Our goal is to build an application which can read the handwritten digits. For this we need some train_data and test_data. OpenCV comes with an image `digits.png` (in the folder ``opencv/samples/python/data/``) which has 5000 handwritten digits (500 for each digit). Each digit is a 20x20 image. So our first step is to split this image into 5000 different digits. For each digit, we flatten it into a single row with 400 pixels. That is our feature set, ie intensity values of all pixels. It is the simplest feature set we can create. We use first 250 samples of each digit as train_data, and next 250 samples as test_data. So let's prepare them first.
 ::
 
     import numpy as np

--- a/source/py_tutorials/py_photo/py_inpainting/py_inpainting.rst
+++ b/source/py_tutorials/py_photo/py_inpainting/py_inpainting.rst
@@ -65,6 +65,6 @@ Additional Resources
 Exercises
 ================
 
-#. OpenCV comes with an interactive sample on inpainting, ``samples/python2/inpaint.py``, try it.
+#. OpenCV comes with an interactive sample on inpainting, ``samples/python/inpaint.py``, try it.
 
 #. A few months ago, I watched a video on `Content-Aware Fill <http://www.youtube.com/watch?v=ZtoUiplKa2A>`_, an advanced inpainting technique used in Adobe Photoshop. On further search, I was able to find that same technique is already there in GIMP with different name, "Resynthesizer" (You need to install separate plugin). I am sure you will enjoy the technique.

--- a/source/py_tutorials/py_video/py_lucas_kanade/py_lucas_kanade.rst
+++ b/source/py_tutorials/py_video/py_lucas_kanade/py_lucas_kanade.rst
@@ -144,7 +144,7 @@ OpenCV provides all these in a single function, **cv2.calcOpticalFlowPyrLK()**. 
     cap.release()
     
 
-(This code doesn't check how correct are the next keypoints. So even if any feature point disappears in image, there is a chance that optical flow finds the next point which may look close to it. So actually for a robust tracking, corner points should be detected in particular intervals. OpenCV samples comes up with such a sample which finds the feature points at every 5 frames. It also run a backward-check of the optical flow points got to select only good ones. Check ``samples/python2/lk_track.py``).
+(This code doesn't check how correct are the next keypoints. So even if any feature point disappears in image, there is a chance that optical flow finds the next point which may look close to it. So actually for a robust tracking, corner points should be detected in particular intervals. OpenCV samples comes up with such a sample which finds the feature points at every 5 frames. It also run a backward-check of the optical flow points got to select only good ones. Check ``samples/python/lk_track.py``).
 
 See the results we got:
 
@@ -199,7 +199,7 @@ See the result below:
         :alt: Dense Optical Flow
         :align: center
         
-OpenCV comes with a more advanced sample on dense optical flow, please see ``samples/python2/opt_flow.py``. 
+OpenCV comes with a more advanced sample on dense optical flow, please see ``samples/python/opt_flow.py``. 
         
 Additional Resources
 ========================
@@ -208,5 +208,5 @@ Additional Resources
 Exercises
 ===========
 
-#. Check the code in ``samples/python2/lk_track.py``. Try to understand the code.
-#. Check the code in ``samples/python2/opt_flow.py``. Try to understand the code.
+#. Check the code in ``samples/python/lk_track.py``. Try to understand the code.
+#. Check the code in ``samples/python/opt_flow.py``. Try to understand the code.


### PR DESCRIPTION
There are broken links and broken references because it refers to samples/python2 instead of samples/python
  