### PR TITLE
Update py_bg_subtraction.rst

### DIFF
--- a/source/py_tutorials/py_video/py_bg_subtraction/py_bg_subtraction.rst
+++ b/source/py_tutorials/py_video/py_bg_subtraction/py_bg_subtraction.rst
@@ -36,18 +36,21 @@ See a simple example below:
 
     cap = cv2.VideoCapture('vtest.avi')
 
-    fgbg = cv2.createBackgroundSubtractorMOG()
+    fgbg = cv2.bgsegm.createBackgroundSubtractorMOG()
 
     while(1):
         ret, frame = cap.read()
-
+   
         fgmask = fgbg.apply(frame)
-        
-        cv2.imshow('frame',fgmask)
-        k = cv2.waitKey(30) & 0xff
-        if k == 27:
-            break
-            
+        try:
+          cv2.imshow('frame',fgmask)
+        except:
+          pass
+        finally:    
+          k = cv2.waitKey(30) & 0xff
+          if k == 27:
+             break
+   
     cap.release()
     cv2.destroyAllWindows()
     
@@ -98,23 +101,26 @@ It would be better to apply morphological opening to the result to remove the no
 
     import numpy as np
     import cv2
-
+    
     cap = cv2.VideoCapture('vtest.avi')
-
+    
     kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE,(3,3))
-    fgbg = cv2.createBackgroundSubtractorGMG()
-
+    fgbg = cv2.bgsegm.createBackgroundSubtractorGMG()
+    
     while(1):
         ret, frame = cap.read()
-
+      
         fgmask = fgbg.apply(frame)
         fgmask = cv2.morphologyEx(fgmask, cv2.MORPH_OPEN, kernel)
-        
-        cv2.imshow('frame',fgmask)
-        k = cv2.waitKey(30) & 0xff
-        if k == 27:
+     
+        try:
+           cv2.imshow('frame',fgmask)
+        except:
+           pass
+        finally:    
+           k = cv2.waitKey(30) & 0xff
+           if k == 27:
             break
-            
     cap.release()
     cv2.destroyAllWindows()
     


### PR DESCRIPTION
System: OpenCV 3.3.1 , python 3.6 ,windows 8.1
 
Found two issues while using background subtraction
A)
 In openCV 3.3.1, the commands :
  1) `cv2.createBackgroundSubtractorMOG() `
  2) `cv2.createBackgroundSubtractorGMG()`
 no longer worked and an error message stating :
`AttributeError: module 'cv2' has no attribute 'createBackgroundSubtractorMOG'`
`AttributeError: module 'cv2' has no attribute 'createBackgroundSubtractorGMG'`
respectively,  were displayed.
After looking through file structure in openCV 3.3.1 using help('cv2'),  found that the above commands were moved to 
`bgsegm` sub-module with the upgrade of openCV from 2.X to 3.X, but the tutorials were not updated. Hence , the above commands for background subtraction would be:
1) `cv2.bgsegm.createBackgroundSubtractorMOG()`
2) `cv2.bgsegm.createBackgroundSubtractorGMG()`

B) 
 Whenever a video reached the last frame an error stating , 
`error: (-215) size.width>0 && size.height>0 in function cv::imshow ` and python kernel crashed when trying to close the image window.
I think it was because EOF for video was not handled properly for the MOG and GMG . 
So to get around this  a try, except and finally block was used , I did try cv2.isOpen(frame) which returns a Boolean (if frame exists) as a condition for while but the problem of kernel crashing still persisted. Thought it was the video problem so try 2 other videos one in .mp4 and another .avi format, but it didn't help. But I do feel a better method exists.

So I would much obliged if you could check these and guide me on what to do next. PS: This is my first contribution to open source.