### PR TITLE
Update py_setup_in_fedora.rst

### DIFF
--- a/source/py_tutorials/py_setup/py_setup_in_fedora/py_setup_in_fedora.rst
+++ b/source/py_tutorials/py_setup/py_setup_in_fedora/py_setup_in_fedora.rst
@@ -24,7 +24,7 @@ Install all packages with following command in terminal as root.
 
     .. code-block:: bash
     
-        $ yum install numpy opencv*
+        $ yum install numpy opencv* python2-opencv
     
 Open Python IDLE (or IPython) and type following codes in Python terminal.
 


### PR DESCRIPTION
I have downloaded Fedora 29 and am am installing OpenCV. Found out that the name of the binary has probably been changed and now you might need to install python2-opencv along with opencv* to actually get cv2 module.