### PR TITLE
Fix Numpy tutorial URLs

### DIFF
--- a/source/py_tutorials/py_setup/py_intro/py_intro.rst
+++ b/source/py_tutorials/py_setup/py_intro/py_intro.rst
@@ -63,7 +63,7 @@ Additional Resources
 =======================
 
 1. A Quick guide to Python - `A Byte of Python <http://swaroopch.com/notes/python/>`_
-2. `Basic Numpy Tutorials <http://wiki.scipy.org/Tentative_NumPy_Tutorial>`_
-3. `Numpy Examples List <http://wiki.scipy.org/Numpy_Example_List>`_
+2. `Basic Numpy Tutorials <https://scipy.github.io/old-wiki/pages/Tentative_NumPy_Tutorial>`_
+3. `Numpy Examples List <2.	https://scipy.github.io/old-wiki/pages/Numpy_Example_List>`_
 4. `OpenCV Documentation <http://docs.opencv.org/>`_
 5. `OpenCV Forum <http://answers.opencv.org/questions/>`_


### PR DESCRIPTION
Old URLs had got obsolete.
Changed them with Newer ones that work.