### PR TITLE
Update to Probabilistic Hough Transform example

### DIFF
--- a/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
+++ b/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
@@ -101,7 +101,7 @@ Best thing is that, it directly returns the two endpoints of lines. In previous 
     minLineLength = 100
     maxLineGap = 10
     lines = cv2.HoughLinesP(edges,1,np.pi/180,100,minLineLength,maxLineGap)
-    for x1,y1,x2,y2 in lines[0]:
+    for x1,y1,x2,y2 in lines[:,0]:
         cv2.line(img,(x1,y1),(x2,y2),(0,255,0),2)
 
     cv2.imwrite('houghlines5.jpg',img)       


### PR DESCRIPTION
It looks like the dimensions were off in the loop adding the lines within the example. The shape returned by HoughLinesP was (num_lines, 1, 4) so to iterate through the nested list, I needed to use 
```python
for x1,y1,x2,y2 in lines[:,0]:
    ...
```