### PR TITLE
Fix Otsu binarization math typo

### DIFF
--- a/source/py_tutorials/py_imgproc/py_thresholding/py_thresholding.rst
+++ b/source/py_tutorials/py_imgproc/py_thresholding/py_thresholding.rst
@@ -169,7 +169,7 @@ Since we are working with bimodal images, Otsu's algorithm tries to find a thres
 where
 
 .. math::
-    q_1(t) = \sum_{i=1}^{t} P(i) \quad \& \quad q_1(t) = \sum_{i=t+1}^{I} P(i) 
+    q_1(t) = \sum_{i=1}^{t} P(i) \quad \& \quad q_2(t) = \sum_{i=t+1}^{I} P(i) 
 
     \mu_1(t) = \sum_{i=1}^{t} \frac{iP(i)}{q_1(t)} \quad \& \quad \mu_2(t) = \sum_{i=t+1}^{I} \frac{iP(i)}{q_2(t)}
 


### PR DESCRIPTION
This fixes a type the Otsu binarization math here: https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_thresholding/py_thresholding.html