### PR TITLE
Update py_colorspaces.rst

### DIFF
--- a/source/py_tutorials/py_imgproc/py_colorspaces/py_colorspaces.rst
+++ b/source/py_tutorials/py_imgproc/py_colorspaces/py_colorspaces.rst
@@ -85,7 +85,7 @@ Below image shows tracking of the blue object:
 
 How to find HSV values to track?
 -----------------------------------
-This is a common question found in `stackoverflow.com <www.stackoverflow.com>`_. It is very simple and you can use the same function, `cv2.cvtColor()`. Instead of passing an image, you just pass the BGR values you want. For example, to find the HSV value of Green, try following commands in Python terminal:
+This is a common question found in `stackoverflow.com <http://www.stackoverflow.com>`_. It is very simple and you can use the same function, `cv2.cvtColor()`. Instead of passing an image, you just pass the BGR values you want. For example, to find the HSV value of Green, try following commands in Python terminal:
 ::
 
     >>> green = np.uint8([[[0,255,0 ]]])


### PR DESCRIPTION
Previously it's going to https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_imgproc/py_colorspaces/www.stackoverflow.com after adding http it redirects to http://stackoverflow.com 