### PR TITLE
Fixed minor error (?) in first example

### DIFF
--- a/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
+++ b/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
@@ -56,15 +56,16 @@ Everything explained above is encapsulated in the OpenCV function, **cv2.HoughLi
     edges = cv2.Canny(gray,50,150,apertureSize = 3)
 
     lines = cv2.HoughLines(edges,1,np.pi/180,200)
-    for rho,theta in lines[0]:
-        a = np.cos(theta)
-        b = np.sin(theta)
-        x0 = a*rho
-        y0 = b*rho
-        x1 = int(x0 + 1000*(-b))   
-        y1 = int(y0 + 1000*(a))    
-        x2 = int(x0 - 1000*(-b))   
-        y2 = int(y0 - 1000*(a))
+    for lines in lines:
+      for rho,theta in lines:
+         a = np.cos(theta)
+         b = np.sin(theta)
+         x0 = a*rho
+         y0 = b*rho
+         x1 = int(x0 + 1000*(-b))   
+         y1 = int(y0 + 1000*(a))    
+         x2 = int(x0 - 1000*(-b))   
+         y2 = int(y0 - 1000*(a))
 
         cv2.line(img,(x1,y1),(x2,y2),(0,0,255),2)
 


### PR DESCRIPTION
Initially the loop was, 
```
for rho,theta in lines[0]:
    a = np.cos(theta)
    b = np.sin(theta)
    x0 = a*rho
    y0 = b*rho
    x1 = int(x0 + 1000*(-b))
    y1 = int(y0 + 1000*(a))
    x2 = int(x0 - 1000*(-b))
    y2 = int(y0 - 1000*(a))

```

this is incorrect because` for rho,theta in lines[0] ` returns `rho, theta` values for only one of the lines, whereas lines is an array of several `rho,theta` pairs. I have updated the loop so that it considers all pairs of rho, theta values.

Proposed edit:

```
for lines in lines:
    for rho,theta in lines:
         a = np.cos(theta)
         b = np.sin(theta)
         x0 = a*rho
         y0 = b*rho
         x1 = int(x0 + 1000*(-b))
         y1 = int(y0 + 1000*(a))
         x2 = int(x0 - 1000*(-b))
         y2 = int(y0 - 1000*(a))
```
Loops through all the values of rho, theta.