### PR TITLE
Fix typo: 'images' instead of 'imagess'

### DIFF
--- a/source/py_tutorials/py_imgproc/py_filtering/py_filtering.rst
+++ b/source/py_tutorials/py_imgproc/py_filtering/py_filtering.rst
@@ -7,7 +7,7 @@ Goals
 =======
 
 Learn to:
-    * Blur  imagess with various low pass filters
+    * Blur  images with various low pass filters
     * Apply custom-made filters to images (2D convolution)
     
 2D Convolution ( Image Filtering )


### PR DESCRIPTION
Hi,

I have noticed that there is a small typo in the documentation. I think that, Instead of 'imagess', it should be 'images'.

Hope it helps!
Miguel