### PR TITLE
Otsu's Binarization, typo at line 172 and line 176

### DIFF
--- a/source/py_tutorials/py_imgproc/py_thresholding/py_thresholding.rst
+++ b/source/py_tutorials/py_imgproc/py_thresholding/py_thresholding.rst
@@ -169,11 +169,11 @@ Since we are working with bimodal images, Otsu's algorithm tries to find a thres
 where
 
 .. math::
-    q_1(t) = \sum_{i=1}^{t} P(i) \quad \& \quad q_1(t) = \sum_{i=t+1}^{I} P(i) 
+    q_1(t) = \sum_{i=1}^{t} P(i) \quad \& \quad q_2(t) = \sum_{i=t+1}^{I} P(i) 
 
     \mu_1(t) = \sum_{i=1}^{t} \frac{iP(i)}{q_1(t)} \quad \& \quad \mu_2(t) = \sum_{i=t+1}^{I} \frac{iP(i)}{q_2(t)}
 
-    \sigma_1^2(t) = \sum_{i=1}^{t} [i-\mu_1(t)]^2 \frac{P(i)}{q_1(t)} \quad \& \quad \sigma_2^2(t) = \sum_{i=t+1}^{I} [i-\mu_1(t)]^2 \frac{P(i)}{q_2(t)}
+    \sigma_1^2(t) = \sum_{i=1}^{t} [i-\mu_1(t)]^2 \frac{P(i)}{q_1(t)} \quad \& \quad \sigma_2^2(t) = \sum_{i=t+1}^{I} [i-\mu_2(t)]^2 \frac{P(i)}{q_2(t)}
 
 It actually finds a value of t which lies in between two peaks such that variances to both classes are minimum. It can be simply implemented in Python as follows:
 ::


### PR DESCRIPTION
At line 172:
q_1(t) = \sum_{i=1}^{t} P(i) \quad \& \quad q_2(t) = \sum_{i=t+1}^{I} P(i) instead of q_1(t) = \sum_{i=1}^{t} P(i) \quad \& \quad q_1(t) = \sum_{i=t+1}^{I} P(i).
In the formula while defining q1 and q2, instead of writing q2(t), it was written q1(t) for q2 definition.

At line 176:
\quad \sigma_2^2(t) = \sum_{i=t+1}^{I} [i-\mu_2(t)]^2 \frac{P(i)}{q_2(t)}. Here, it was written [i-\mu_1(t)]^2 instead of [i-\mu_2(t)]^2.