### PR TITLE
Corrected code sample iteration

### DIFF
--- a/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
+++ b/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
@@ -56,7 +56,7 @@ Everything explained above is encapsulated in the OpenCV function, **cv2.HoughLi
     edges = cv2.Canny(gray,50,150,apertureSize = 3)
 
     lines = cv2.HoughLines(edges,1,np.pi/180,200)
-    for rho,theta in lines[0]:
+    for rho,theta in lines[:,0]:
         a = np.cos(theta)
         b = np.sin(theta)
         x0 = a*rho
@@ -101,7 +101,7 @@ Best thing is that, it directly returns the two endpoints of lines. In previous 
     minLineLength = 100
     maxLineGap = 10
     lines = cv2.HoughLinesP(edges,1,np.pi/180,100,minLineLength,maxLineGap)
-    for x1,y1,x2,y2 in lines[0]:
+    for x1,y1,x2,y2 in lines[:,0]:
         cv2.line(img,(x1,y1),(x2,y2),(0,255,0),2)
 
     cv2.imwrite('houghlines5.jpg',img)       


### PR DESCRIPTION
Code samples do not iterate through all detected lines in an image. Instead, it only draws the first detected line. 
Replaced lines[0] by lines[:,0] at lines 59 and 104 to get the desired behavior.