### PR TITLE
Updated FAST example to Python3

### DIFF
--- a/source/py_tutorials/py_feature2d/py_fast/py_fast.rst
+++ b/source/py_tutorials/py_feature2d/py_fast/py_fast.rst
@@ -93,29 +93,29 @@ For the neighborhood, three flags are defined, ``cv2.FAST_FEATURE_DETECTOR_TYPE_
     img = cv2.imread('simple.jpg',0)
 
     # Initiate FAST object with default values
-    fast = cv2.FastFeatureDetector()
+    fast = cv2.FastFeatureDetector_create()
 
     # find and draw the keypoints
-    kp = fast.detect(img,None)
-    img2 = cv2.drawKeypoints(img, kp, color=(255,0,0))
+    kp = fast.detect(img, None)
+    img2 = cv2.drawKeypoints(img, kp, None, color=(255,0,0))
 
     # Print all default params
-    print "Threshold: ", fast.getInt('threshold')
-    print "nonmaxSuppression: ", fast.getBool('nonmaxSuppression')
-    print "neighborhood: ", fast.getInt('type')
-    print "Total Keypoints with nonmaxSuppression: ", len(kp) 
+    print("Threshold: ", fast.getThreshold())
+    print("nonmaxSuppression: ", fast.getNonmaxSuppression())
+    print("neighborhood: ", fast.getType())
+    print("Total Keypoints with nonmaxSuppression: ", len(kp))  
 
-    cv2.imwrite('fast_true.png',img2)
+    cv2.imwrite('fast_true.png', img2)
 
     # Disable nonmaxSuppression
-    fast.setBool('nonmaxSuppression',0)
-    kp = fast.detect(img,None)
+    fast.setNonmaxSuppression(0)
+    kp = fast.detect(img, None)
 
-    print "Total Keypoints without nonmaxSuppression: ", len(kp) 
+    print("Total Keypoints without nonmaxSuppression: ", len(kp))  
 
-    img3 = cv2.drawKeypoints(img, kp, color=(255,0,0))
+    img3 = cv2.drawKeypoints(img, kp, None, color=(255,0,0))
 
-    cv2.imwrite('fast_false.png',img3)
+    cv2.imwrite('fast_false.png', img3)
     
 See the results. First image shows FAST with nonmaxSuppression and second one without nonmaxSuppression:
 


### PR DESCRIPTION
Changed FastFeatureDetector to FastFeatureDetector_create and updated the code from Python2 to Python3. The example in the current documentation doesn't work in newest versions of OpenCV.