### PR TITLE
Fix findContours statement in Getting Started

### DIFF
--- a/source/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.rst
+++ b/source/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.rst
@@ -28,9 +28,9 @@ Let's see how to find contours of a binary image:
     im = cv2.imread('test.jpg')
     imgray = cv2.cvtColor(im,cv2.COLOR_BGR2GRAY)
     ret,thresh = cv2.threshold(imgray,127,255,0)
-    image, contours, hierarchy = cv2.findContours(thresh,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
+    contours, hierarchy = cv2.findContours(thresh,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
 
-See, there are three arguments in **cv2.findContours()** function, first one is source image, second is contour retrieval mode, third is contour approximation method. And it outputs the image, contours and hierarchy. ``contours`` is a Python list of all the contours in the image. Each individual contour is a Numpy array of (x,y) coordinates of boundary points of the object.
+See, there are three arguments in **cv2.findContours()** function, first one is source image, second is contour retrieval mode, third is contour approximation method. And it outputs the contours and hierarchy. ``contours`` is a Python list of all the contours in the image. Each individual contour is a Numpy array of (x,y) coordinates of boundary points of the object.
 
 .. note:: We will discuss second and third arguments and about hierarchy in details later. Until then, the values given to them in code sample will work fine for all images. 
 


### PR DESCRIPTION
The Contours: Getting Started document has a findContours() call that fails because it lists three return values: image, contours and hierarchy. However this fails as findContours() only returns two values: contours and hierarchy.

See https://docs.opencv.org/2.4/modules/imgproc/doc/structural_analysis_and_shape_descriptors.html#findcontours