### PR TITLE
Fixed the bug in the example given

### DIFF
--- a/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
+++ b/source/py_tutorials/py_imgproc/py_houghlines/py_houghlines.rst
@@ -56,7 +56,8 @@ Everything explained above is encapsulated in the OpenCV function, **cv2.HoughLi
     edges = cv2.Canny(gray,50,150,apertureSize = 3)
 
     lines = cv2.HoughLines(edges,1,np.pi/180,200)
-    for rho,theta in lines[0]:
+    for line in lines:
+        rho, theta = line[0]
         a = np.cos(theta)
         b = np.sin(theta)
         x0 = a*rho
@@ -101,7 +102,8 @@ Best thing is that, it directly returns the two endpoints of lines. In previous 
     minLineLength = 100
     maxLineGap = 10
     lines = cv2.HoughLinesP(edges,1,np.pi/180,100,minLineLength,maxLineGap)
-    for x1,y1,x2,y2 in lines[0]:
+    for line in lines:
+        x1,y1,x2,y2 = line[0]
         cv2.line(img,(x1,y1),(x2,y2),(0,255,0),2)
 
     cv2.imwrite('houghlines5.jpg',img)       


### PR DESCRIPTION
The code above just gave only one line in the final output, though the example image that was being shown was completely different. I fixed the example code now.