### PR TITLE
cv2.findContours() updated in newer versions

### DIFF
--- a/source/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.rst
+++ b/source/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.rst
@@ -33,7 +33,7 @@ Let's see how to find contours of a binary image:
 See, there are three arguments in **cv2.findContours()** function, first one is source image, second is contour retrieval mode, third is contour approximation method. And it outputs the image, contours and hierarchy. ``contours`` is a Python list of all the contours in the image. Each individual contour is a Numpy array of (x,y) coordinates of boundary points of the object.
 
 .. note:: We will discuss second and third arguments and about hierarchy in details later. Until then, the values given to them in code sample will work fine for all images. 
-
+If you are using OpenCV version >=3.2, **cv2.findContours()** function returns only two arguments - ``contours`` and ``hierarchy``, it no longer makes any changes on the source image. So changing the code to use ``contours, hierarchy = cv2.findContours(thresh,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)`` should work.
 
 How to draw the contours?
 ===========================


### PR DESCRIPTION
cv2.findContours() no longer makes changes on the source image. (Newer Versions)
It takes in only 2 arguments instead of 3 as shown in the block of code. Upon executing the code, error will be thrown stating "only returns two objects, you're trying to unpack it into three."
Added a small note, how to deal with it if the user is using a newer version of OpenCV later than 3.2