### PR TITLE
Use imread flag instead of integer as parameter

### DIFF
--- a/source/py_tutorials/py_gui/py_image_display/py_image_display.rst
+++ b/source/py_tutorials/py_gui/py_image_display/py_image_display.rst
@@ -8,7 +8,7 @@ Goals
 
 .. container:: enumeratevisibleitemswithsquare
 
-    * Here, you will learn how to read an image, how to display it and how to save it back
+    * Here, you will learn how to read an image, display it and save it
     * You will learn these functions : **cv2.imread()**, **cv2.imshow()** , **cv2.imwrite()**
     * Optionally, you will learn how to display images with Matplotlib
 
@@ -18,13 +18,13 @@ Using OpenCV
 Read an image
 --------------
 
-Use the function **cv2.imread()** to read an image. The image should be in the working directory or a full path of image should be given.
+Use the function **cv2.imread()** to read an image. The image should be in the working directory, or the full path of the image should be given.
 
-Second argument is a flag which specifies the way image should be read.
+The second argument is a flag which specifies the way image should be read.
 
-* cv2.IMREAD_COLOR : Loads a color image. Any transparency of image will be neglected. It is the default flag.
-* cv2.IMREAD_GRAYSCALE : Loads image in grayscale mode
-* cv2.IMREAD_UNCHANGED : Loads image as such including alpha channel
+* cv2.IMREAD_COLOR : Loads a color image. Transparency will be neglected. This is the default flag.
+* cv2.IMREAD_GRAYSCALE : Loads image in grayscale mode.
+* cv2.IMREAD_UNCHANGED : Loads image as such including alpha channel (transparency).
 
 See the code below:
 ::
@@ -35,31 +35,31 @@ See the code below:
     # Load an color image in grayscale
     img = cv2.imread('messi5.jpg', cv2.IMREAD_GRAYSCALE)
     
-.. warning:: Even if the image path is wrong, it won't throw any error, but ``print img`` will give you ``None``
+.. warning:: If the image path is wrong, this won't throw any error, but ``print img`` will return ``None``
 
 Display an image
 -----------------
 
 Use the function **cv2.imshow()** to display an image in a window. The window automatically fits to the image size.
 
-First argument is a window name which is a string. second argument is our image. You can create as many windows as you wish, but with different window names.
+The first argument is a window name which is a string. The second argument is our image. You can create as many windows as you wish, by using different window names.
 ::
     
     cv2.imshow('image',img)
     cv2.waitKey(0)
     cv2.destroyAllWindows()
 
-A screenshot of the window will look like this (in Fedora-Gnome machine):
+The window will look like this (on a Fedora-Gnome machine):
 
      .. image:: images/opencv_screenshot.jpg
               :alt: Screenshot of Image Window in OpenCV
               :align: center 
    
-**cv2.waitKey()** is a keyboard binding function. Its argument is the time in milliseconds. The function waits for specified milliseconds for any keyboard event. If you press any key in that time, the program continues. If **0** is passed, it waits indefinitely for a key stroke. It can also be set to detect specific key strokes like, if key `a` is pressed etc which we will discuss below.
+**cv2.waitKey()** is a keyboard binding function that waits for any keyboard event. If any key is pressed, the program continues. Its argument is the wait time in milliseconds. If **0** is passed, it waits indefinitely for a key stroke. It can also be set to detect specific key strokes like, if key `a` is pressed (see below).
 
-**cv2.destroyAllWindows()** simply destroys all the windows we created. If you want to destroy any specific window, use the function **cv2.destroyWindow()** where you pass the exact window name as the argument.
+**cv2.destroyAllWindows()** destroys all the windows we created. If you want to destroy a specific window, use the function **cv2.destroyWindow()** where you pass the exact window name as the argument.
 
-.. note:: There is a special case where you can already create a window and load image to it later. In that case, you can specify whether window is resizable or not. It is done with the function **cv2.namedWindow()**. By default, the flag is ``cv2.WINDOW_AUTOSIZE``. But if you specify flag to be ``cv2.WINDOW_NORMAL``, you can resize window. It will be helpful when image is too large in dimension and adding track bar to windows.
+.. note:: There is a special case where you can already create a window and load image to it later. In that case, you can specify whether the window is resizable or not, by using the function **cv2.namedWindow()**. By default, the flag is ``cv2.WINDOW_AUTOSIZE``. But if you specify the flag to be ``cv2.WINDOW_NORMAL``, you can resize the window. This is helpful for large images that need scrollbars.
 
 See the code below:
 ::
@@ -74,7 +74,7 @@ Write an image
 
 Use the function **cv2.imwrite()** to save an image.
 
-First argument is the file name, second argument is the image you want to save.
+The first argument is the file name, the second argument is the image you want to save.
 ::
     
     cv2.imwrite('messigray.png',img)
@@ -99,12 +99,12 @@ Below program loads an image in grayscale, displays it, save the image if you pr
         cv2.imwrite('messigray.png',img)
         cv2.destroyAllWindows()
     
-.. warning:: If you are using a 64-bit machine, you will have to modify ``k = cv2.waitKey(0)`` line as follows : ``k = cv2.waitKey(0) & 0xFF``
+.. warning:: If you are using a 64-bit machine, you will have to modify the line ``k = cv2.waitKey(0)`` as follows : ``k = cv2.waitKey(0) & 0xFF``
 
 Using Matplotlib
 =================
 
-Matplotlib is a plotting library for Python which gives you wide variety of plotting methods. You will see them in coming articles. Here, you will learn how to display image with Matplotlib. You can zoom images, save it etc using Matplotlib.
+Matplotlib is a plotting library for Python that offers a wide variety of plotting methods. Here, you will learn how to display an image with Matplotlib. With it, you can zoom into images, save them, and more.
 ::
     
     import numpy as np
@@ -116,13 +116,13 @@ Matplotlib is a plotting library for Python which gives you wide variety of plot
     plt.xticks([]), plt.yticks([])  # to hide tick values on X and Y axis
     plt.show()
     
-A screen-shot of the window will look like this :
+The window will look like this :
 
      .. image:: images/matplotlib_screenshot.jpg
               :alt: Screenshot of Image Window in Matplotlib
               :align: center 
     
-.. seealso:: Plenty of plotting options are available in Matplotlib. Please refer to Matplotlib docs for more details. Some, we will see on the way.
+.. seealso:: Plenty of plotting options are available in Matplotlib. Please refer to the Matplotlib docs for more details. Some of them will be demonstrated within these tutorials.
 
 .. warning:: Color image loaded by OpenCV is in BGR mode. But Matplotlib displays in RGB mode. So color images will not be displayed correctly in Matplotlib if image is read with OpenCV. Please see the exercises for more details.
 
@@ -134,4 +134,4 @@ Additional Resources
 Exercises
 ==========
 
-#. There is some problem when you try to load color image in OpenCV and display it in Matplotlib. Read `this discussion <http://stackoverflow.com/a/15074748/1134940>`_ and understand it.
+#. There can be problems when you try to load a color image in OpenCV and display it in Matplotlib. Read `this discussion <http://stackoverflow.com/a/15074748/1134940>`_ for details.

--- a/source/py_tutorials/py_gui/py_image_display/py_image_display.rst
+++ b/source/py_tutorials/py_gui/py_image_display/py_image_display.rst
@@ -26,8 +26,6 @@ Second argument is a flag which specifies the way image should be read.
 * cv2.IMREAD_GRAYSCALE : Loads image in grayscale mode
 * cv2.IMREAD_UNCHANGED : Loads image as such including alpha channel
 
-.. note:: Instead of these three flags, you can simply pass integers 1, 0 or -1 respectively.
-
 See the code below:
 ::
     
@@ -35,7 +33,7 @@ See the code below:
     import cv2
     
     # Load an color image in grayscale
-    img = cv2.imread('messi5.jpg',0)
+    img = cv2.imread('messi5.jpg', cv2.IMREAD_GRAYSCALE)
     
 .. warning:: Even if the image path is wrong, it won't throw any error, but ``print img`` will give you ``None``
 
@@ -92,7 +90,7 @@ Below program loads an image in grayscale, displays it, save the image if you pr
     import numpy as np
     import cv2
     
-    img = cv2.imread('messi5.jpg',0)
+    img = cv2.imread('messi5.jpg', cv2.IMREAD_GRAYSCALE)
     cv2.imshow('image',img)
     k = cv2.waitKey(0)
     if k == 27:         # wait for ESC key to exit
@@ -113,7 +111,7 @@ Matplotlib is a plotting library for Python which gives you wide variety of plot
     import cv2
     from matplotlib import pyplot as plt
     
-    img = cv2.imread('messi5.jpg',0)
+    img = cv2.imread('messi5.jpg', cv2.IMREAD_GRAYSCALE)
     plt.imshow(img, cmap = 'gray', interpolation = 'bicubic')
     plt.xticks([]), plt.yticks([])  # to hide tick values on X and Y axis
     plt.show()


### PR DESCRIPTION
I think that not using the flag makes the code less readable, and contradicts the reason why the flags exist in the first place. New users do not profit from having to remember the raw integer.

I also took the liberty of fixing some language issues and make some style changes, but feel free to revert them.