### PR TITLE
Add fourcc codec for writing to OS X

### DIFF
--- a/source/py_tutorials/py_gui/py_video_display/py_video_display.rst
+++ b/source/py_tutorials/py_gui/py_video_display/py_video_display.rst
@@ -89,7 +89,7 @@ This time we create a **VideoWriter** object. We should specify the output file 
 
 * In Fedora: DIVX, XVID, MJPG, X264, WMV1, WMV2. (XVID is more preferable. MJPG results in high size video. X264 gives very small size video)
 * In Windows: DIVX (More to be tested and added)
-* In OSX : *(I don't have access to OSX. Can some one fill this?)*
+* In OSX : MJPG
 
 FourCC code is passed as ``cv2.VideoWriter_fourcc('M','J','P','G')`` or ``cv2.VideoWriter_fourcc(*'MJPG)`` for MJPG.
 


### PR DESCRIPTION
Tested with Big Sur 11.2.3, only MJPG works with the Quicktime player